### PR TITLE
Prevent duplicate logging handlers in app initialization

### DIFF
--- a/smart_lighting_ai_dali/logging_config.py
+++ b/smart_lighting_ai_dali/logging_config.py
@@ -4,6 +4,9 @@ import json
 import logging
 
 
+JSON_HANDLER_ATTR = "_smart_lighting_json_handler"
+
+
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:  # noqa: D401
         data = {
@@ -21,10 +24,16 @@ class JsonFormatter(logging.Formatter):
 
 
 def configure_logging() -> None:
-    handler = logging.StreamHandler()
-    handler.setFormatter(JsonFormatter())
     root = logging.getLogger()
     root.setLevel(logging.INFO)
+
+    for handler in root.handlers:
+        if getattr(handler, JSON_HANDLER_ATTR, False):
+            return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    setattr(handler, JSON_HANDLER_ATTR, True)
     root.addHandler(handler)
 
 

--- a/smart_lighting_ai_dali/main.py
+++ b/smart_lighting_ai_dali/main.py
@@ -33,10 +33,16 @@ from .schemas import (
 
 logger = logging.getLogger(__name__)
 
+_LOGGING_CONFIGURED = False
+
 
 def create_app(settings: Optional[Settings] = None, *, use_mock_dali: bool = True) -> FastAPI:
+    global _LOGGING_CONFIGURED
+
     settings = settings or get_settings()
-    configure_logging()
+    if not _LOGGING_CONFIGURED:
+        configure_logging()
+        _LOGGING_CONFIGURED = True
     Base.metadata.create_all(bind=engine)
     dali = MockDALIInterface() if use_mock_dali else TridonicUSBInterface()
     control_service = ControlService(dali=dali, settings=settings)
@@ -49,6 +55,7 @@ def create_app(settings: Optional[Settings] = None, *, use_mock_dali: bool = Tru
     app.state.control_service = control_service
     app.state.ai_controller = ai_controller
     app.state.rate_limiter = rate_limiter
+    app.state.logging_configured = True
 
     def feature_job() -> None:
         with engine.begin() as connection:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+
+
+def test_create_app_configures_logging_once():
+    from smart_lighting_ai_dali.main import create_app
+
+    root_logger = logging.getLogger()
+
+    app1 = create_app()
+    app2 = create_app()
+
+    handlers = [
+        handler
+        for handler in root_logger.handlers
+        if getattr(handler, "_smart_lighting_json_handler", False)
+    ]
+
+    assert len(handlers) == 1
+    assert app1.state.logging_configured is True
+    assert app2.state.logging_configured is True
+
+    for app in (app1, app2):
+        scheduler = getattr(app.state, "scheduler", None)
+        if scheduler is not None and scheduler.running:
+            try:
+                scheduler.shutdown(wait=False)
+            except Exception:  # noqa: BLE001
+                pass


### PR DESCRIPTION
## Summary
- make the JSON logging setup idempotent by reusing the existing handler when present
- guard `create_app` from re-running logging setup and expose a state flag once configured
- add a regression test ensuring repeated `create_app` calls do not accumulate handlers

## Testing
- pytest tests/test_logging_config.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68e0f7f5da5c8321a5a031fa0c1740d3