### PR TITLE
Handle oversized predict payloads

### DIFF
--- a/smart_lighting_ai_dali/main.py
+++ b/smart_lighting_ai_dali/main.py
@@ -122,7 +122,13 @@ def create_app(settings: Optional[Settings] = None, *, use_mock_dali: bool = Tru
             FeatureWindow(payload=window, timestamp=datetime.utcnow().isoformat())
             for window in windows
         ]
-        setpoint, payload_size = ai_controller.compute_setpoint(feature_windows)
+        try:
+            setpoint, payload_size = ai_controller.compute_setpoint(feature_windows)
+        except ValueError as exc:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": str(exc)},
+            )
         feature_row = (
             db.query(FeatureRow)
             .order_by(FeatureRow.created_at.desc())


### PR DESCRIPTION
## Summary
- return a 400 response when the AI setpoint computation raises a ValueError due to payload limits
- add a regression test ensuring oversized predict payloads surface as client errors

## Testing
- pytest tests/test_api_predict_control.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f81d060083218825fe7257487f1d