### PR TITLE
Handle OpenAI response text attributes

### DIFF
--- a/tests/test_ai_controller.py
+++ b/tests/test_ai_controller.py
@@ -14,7 +14,19 @@ class FakeResponses:
     def create(self, **kwargs):  # noqa: ANN001, ANN003
         class _Response:
             def __init__(self, payload):
-                self.output = [[{"content": [{"text": json.dumps(payload)}]}]]
+                class _TextBlock:
+                    def __init__(self, value):
+                        self.value = value
+
+                class _ContentBlock:
+                    def __init__(self, value):
+                        self.text = _TextBlock(value)
+
+                class _OutputBlock:
+                    def __init__(self, value):
+                        self.content = [_ContentBlock(value)]
+
+                self.output = [_OutputBlock(json.dumps(payload))]
 
         return _Response(self.payload)
 


### PR DESCRIPTION
## Summary
- guard AIController response parsing against empty OpenAI responses while using attribute access
- update AI controller tests to mimic ResponseOutput objects and cover the parsing path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0f820456c8321a628bf0586a4b29e