### PR TITLE
Enforce override duration validation for manual overrides

### DIFF
--- a/smart_lighting_ai_dali/schemas.py
+++ b/smart_lighting_ai_dali/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class SensorIngest(BaseModel):
@@ -37,6 +37,12 @@ class ControlRequest(BaseModel):
     source: str = Field("ai")
     manual_override: bool = False
     override_minutes: int | None = Field(default=None, ge=5, le=180)
+
+    @model_validator(mode="after")
+    def validate_manual_override(self) -> "ControlRequest":
+        if self.manual_override and self.override_minutes is None:
+            raise ValueError("override_minutes is required when manual_override is true")
+        return self
 
 
 class ControlResponse(BaseModel):

--- a/tests/test_api_predict_control.py
+++ b/tests/test_api_predict_control.py
@@ -67,3 +67,15 @@ def test_control_endpoint_and_pagination(client, db_session):
     telemetry_data = telemetry.json()
     assert len(telemetry_data["items"]) == 1
     assert telemetry_data["next_offset"] is None or telemetry_data["next_offset"] >= 1
+
+
+def test_control_requires_override_minutes_when_manual_override_enabled(client):
+    response = client.post(
+        "/control",
+        json={
+            "intensity": 50,
+            "cct": 4000,
+            "manual_override": True,
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add a post-init validator to ControlRequest to require override_minutes when manual_override is true
- cover the validation with an API test expecting a 422 response

## Testing
- pytest tests/test_api_predict_control.py::test_control_requires_override_minutes_when_manual_override_enabled

------
https://chatgpt.com/codex/tasks/task_e_68e0f8211d3483218c4e298c324e539e