### PR TITLE
Add mock DALI simulation mode and tooling

### DIFF
--- a/scripts/ingest_weather.py
+++ b/scripts/ingest_weather.py
@@ -1,0 +1,10 @@
+"""CLI entry point for posting simulated weather observations."""
+
+from __future__ import annotations
+
+from smart_lighting_ai_dali.scripts.ingest_weather import ingest, parse_args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    ingest(args.endpoint, args.interval, args.duration, args.seed)

--- a/scripts/simulate_sensor.py
+++ b/scripts/simulate_sensor.py
@@ -1,0 +1,10 @@
+"""CLI entry point for sensor simulation in development mode."""
+
+from __future__ import annotations
+
+from smart_lighting_ai_dali.scripts.simulate_sensor import parse_args, simulate
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    simulate(args.endpoint, args.interval, args.duration, args.seed)

--- a/smart_lighting_ai_dali/config.py
+++ b/smart_lighting_ai_dali/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     anti_flicker_delta_per_second: int = Field(20)
     min_update_interval_seconds: int = Field(5)
 
+    use_mock_dali: bool = Field(False, validation_alias="USE_MOCK_DALI")
+
     quiet_hours_start: int = Field(22)
     quiet_hours_end: int = Field(6)
 

--- a/smart_lighting_ai_dali/dali/__init__.py
+++ b/smart_lighting_ai_dali/dali/__init__.py
@@ -2,6 +2,7 @@
 
 from .interface import (
     DALIInterface,
+    MockDALIController,
     MockDALIInterface,
     TridonicUSBInterface,
     clamp_cct,
@@ -11,6 +12,7 @@ from .interface import (
 
 __all__ = [
     "DALIInterface",
+    "MockDALIController",
     "MockDALIInterface",
     "TridonicUSBInterface",
     "clamp_intensity",

--- a/smart_lighting_ai_dali/dali/interface.py
+++ b/smart_lighting_ai_dali/dali/interface.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
 import logging
+import random
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Any, Dict
+
+from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 
 
 def clamp_intensity(intensity: int) -> int:
+    """Clamp an intensity value to the valid 0-100 range."""
+
     return max(0, min(100, int(intensity)))
 
 
 def clamp_cct(cct: int) -> int:
+    """Clamp a correlated colour temperature to the valid DT8 range."""
+
     return max(1800, min(6500, int(cct)))
 
 
@@ -32,6 +40,11 @@ class DALIInterface(ABC):
     @abstractmethod
     def diagnostics(self) -> dict[str, str]:
         """Return diagnostics information."""
+
+    def read_sensor(self) -> dict[str, int]:  # pragma: no cover - optional
+        """Return a mock sensor reading if supported."""
+
+        raise NotImplementedError
 
 
 def dt8_warm_cool_to_bytes(cct: int) -> bytes:
@@ -94,4 +107,109 @@ class MockDALIInterface(DALIInterface):
             "last_intensity": str(last.data[0]),
             "last_cct_value": str(int.from_bytes(last.data[1:], "big")),
             "commands_sent": str(len(self.sent_commands)),
+        }
+
+
+class MockDALIController(DALIInterface):
+    """In-memory mock controller mirroring basic Tridonic USB DT8 behaviour."""
+
+    def __init__(
+        self,
+        settings=None,
+        *,
+        seed: int | None = None,
+    ) -> None:
+        self.settings = settings or get_settings()
+        self._rng = random.Random(seed or 0)
+        self._clock = 0.0
+        self._last_update_tick = -float(self.settings.min_update_interval_seconds)
+        self._state: Dict[str, Any] = {
+            "intensity": 0,
+            "cct": 4000,
+            "timestamp": self._clock,
+        }
+        self._history: list[Dict[str, Any]] = []
+        self._last_response: Dict[str, Any] | None = None
+
+    def _tick(self, seconds: float = 1.0) -> float:
+        self._clock = round(self._clock + seconds, 3)
+        return self._clock
+
+    def _limit_delta(self, current: int, target: int, limit: float) -> int:
+        delta = target - current
+        if abs(delta) <= limit:
+            return int(target)
+        step = limit if delta > 0 else -limit
+        return int(current + step)
+
+    def set_light(self, intensity: int, cct: int) -> dict[str, Any]:
+        """Apply a light state while respecting anti-flicker bounds."""
+
+        intensity = clamp_intensity(intensity)
+        cct = clamp_cct(cct)
+        elapsed = self._clock - self._last_update_tick
+        applied = True
+        if elapsed < self.settings.min_update_interval_seconds:
+            applied = False
+            intensity = int(self._state["intensity"])
+            cct = int(self._state["cct"])
+        else:
+            max_delta = (
+                self.settings.anti_flicker_delta_per_second * max(elapsed, 1.0)
+            )
+            new_intensity = self._limit_delta(
+                int(self._state["intensity"]),
+                intensity,
+                max_delta,
+            )
+            new_cct = self._limit_delta(
+                int(self._state["cct"]),
+                cct,
+                max_delta * 20,
+            )
+            applied = (
+                new_intensity != self._state["intensity"]
+                or new_cct != self._state["cct"]
+            )
+            self._state["intensity"] = new_intensity
+            self._state["cct"] = new_cct
+            self._last_update_tick = self._clock
+
+        timestamp = self._tick()
+        self._state["timestamp"] = timestamp
+        snapshot = dict(self._state)
+        self._history.append(snapshot)
+        logger.info(
+            "Mock DALI applied setpoint",
+            extra={"state": snapshot, "applied": applied},
+        )
+        self._last_response = {"status": "ok", "applied": applied, "state": snapshot}
+        return self._last_response
+
+    def send_dt8(self, intensity: int, cct: int) -> None:
+        self.set_light(intensity, cct)
+
+    def read_sensor(self) -> dict[str, int]:
+        """Return a deterministic pseudo-random sensor observation."""
+
+        timestamp = self._tick()
+        baseline = max(80, 600 - int(self._state["intensity"]) * 3)
+        lux = max(10, int(baseline + self._rng.randint(-20, 20)))
+        presence_threshold = 0.3 + (int(self._state["intensity"]) / 250.0)
+        presence = 1 if self._rng.random() < min(presence_threshold, 0.9) else 0
+        reading = {"lux": lux, "presence": presence}
+        logger.debug(
+            "Mock sensor reading",
+            extra={"reading": {**reading, "timestamp": timestamp}},
+        )
+        return reading
+
+    def diagnostics(self) -> dict[str, str]:
+        state = self._last_response["state"] if self._last_response else self._state
+        return {
+            "status": "mock",
+            "mode": "mock",
+            "intensity": str(int(state["intensity"])),
+            "cct": str(int(state["cct"])),
+            "clock": f"{self._clock:.3f}",
         }

--- a/smart_lighting_ai_dali/scripts/ingest_weather.py
+++ b/smart_lighting_ai_dali/scripts/ingest_weather.py
@@ -1,30 +1,91 @@
+"""Emit periodic weather observations to the local API."""
+
 from __future__ import annotations
 
 import argparse
-import json
-from datetime import datetime
+import itertools
+import random
+import time
+from datetime import datetime, timedelta
+from typing import Iterator
 
 import requests
 
+_WEATHER_PRESETS = (
+    {"weather_summary": "Clear", "temperature_c": 18.5},
+    {"weather_summary": "Overcast", "temperature_c": 16.0},
+    {"weather_summary": "Rain", "temperature_c": 14.5},
+    {"weather_summary": "Partly Cloudy", "temperature_c": 17.2},
+)
 
-def ingest(api_endpoint: str, json_path: str) -> None:
-    with open(json_path, "r", encoding="utf-8") as handle:
-        data = json.load(handle)
-    payload = {
-        "weather_summary": data["weather_summary"],
-        "temperature_c": data.get("temperature_c"),
-        "sunrise": data.get("sunrise") or datetime.utcnow().isoformat(),
-        "sunset": data.get("sunset") or datetime.utcnow().isoformat(),
-        "timestamp": data.get("timestamp") or datetime.utcnow().isoformat(),
-    }
-    response = requests.post(api_endpoint, json=payload, timeout=5)
-    response.raise_for_status()
-    print("weather ingested", response.json())
+
+def _iter_weather(rng: random.Random) -> Iterator[dict[str, str | float]]:
+    """Yield preset weather observations with slight deterministic variance."""
+
+    base_time = datetime.utcnow()
+    for idx, preset in enumerate(itertools.cycle(_WEATHER_PRESETS)):
+        jitter = rng.uniform(-0.5, 0.5)
+        timestamp = base_time + timedelta(minutes=idx * 10)
+        sunrise = timestamp.replace(hour=6, minute=15, second=0, microsecond=0)
+        sunset = timestamp.replace(hour=18, minute=45, second=0, microsecond=0)
+        yield {
+            "weather_summary": preset["weather_summary"],
+            "temperature_c": round(preset["temperature_c"] + jitter, 1),
+            "sunrise": sunrise.isoformat(),
+            "sunset": sunset.isoformat(),
+            "timestamp": timestamp.isoformat(),
+        }
+
+
+def ingest(endpoint: str, interval: float, duration: float, seed: int | None) -> None:
+    """Post simulated weather data to the ingest endpoint."""
+
+    rng = random.Random(seed or 0)
+    iterator = _iter_weather(rng)
+    end_time = time.monotonic() + duration if duration > 0 else None
+    idx = 0
+    while True:
+        payload = next(iterator)
+        response = requests.post(endpoint, json=payload, timeout=5)
+        response.raise_for_status()
+        print(f"[{idx}] weather {payload} -> {response.json()}")
+        idx += 1
+        if end_time is None:
+            time.sleep(interval)
+            continue
+        if time.monotonic() >= end_time:
+            break
+        time.sleep(interval)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        default="http://localhost:8000/ingest/weather",
+        help="Weather ingest endpoint (default: http://localhost:8000/ingest/weather)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=60.0,
+        help="Interval in seconds between posts (default: 60)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=300.0,
+        help="Total duration in seconds to run the ingestion (default: 300)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=7,
+        help="Random seed for deterministic jitter (default: 7)",
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("endpoint", help="Weather ingest endpoint")
-    parser.add_argument("json", help="JSON file with weather data")
-    args = parser.parse_args()
-    ingest(args.endpoint, args.json)
+    args = parse_args()
+    ingest(args.endpoint, args.interval, args.duration, args.seed)

--- a/smart_lighting_ai_dali/scripts/simulate_sensor.py
+++ b/smart_lighting_ai_dali/scripts/simulate_sensor.py
@@ -1,36 +1,82 @@
+"""Utility for sending deterministic sensor telemetry to the API."""
+
 from __future__ import annotations
 
 import argparse
-import csv
+import random
+import time
 from datetime import datetime
+from typing import Iterator
 
 import requests
 
 
-def simulate(endpoint: str, csv_path: str) -> None:
-    with open(csv_path, "r", newline="") as handle:
-        reader = csv.DictReader(handle)
-        for row in reader:
-            timestamp = row.get("timestamp") or datetime.utcnow().isoformat()
-            payload = {
-                "ambient_lux": float(row["ambient_lux"]),
-                "presence": bool(int(row["presence"])),
-                "timestamp": timestamp,
-            }
-            response = requests.post(endpoint, json=payload, timeout=5)
-            response.raise_for_status()
-            print("sent", payload, "->", response.json())
+def _iter_readings(rng: random.Random) -> Iterator[dict[str, float | int | str]]:
+    """Yield pseudo-randomised sensor readings suitable for ingestion."""
+
+    step = 0
+    while True:
+        base = 320 + 45 * rng.random()
+        oscillation = 30 * (1 if step % 2 else -1)
+        presence = 1 if rng.random() < 0.55 else 0
+        ambient_lux = max(40.0, base + oscillation + presence * 60)
+        yield {
+            "ambient_lux": round(ambient_lux, 2),
+            "presence": bool(presence),
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        step += 1
+
+
+def simulate(endpoint: str, interval: float, duration: float, seed: int | None) -> None:
+    """Post sensor readings to the ingest endpoint at the desired cadence."""
+
+    rng = random.Random(seed or 0)
+    iterator = _iter_readings(rng)
+    end_time = time.monotonic() + duration if duration > 0 else None
+    idx = 0
+    while True:
+        reading = next(iterator)
+        response = requests.post(endpoint, json=reading, timeout=5)
+        response.raise_for_status()
+        print(f"[{idx}] sent {reading} -> {response.json()}")
+        idx += 1
+        if end_time is None:
+            time.sleep(interval)
+            continue
+        if time.monotonic() >= end_time:
+            break
+        time.sleep(interval)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        default="http://localhost:8000/ingest/sensor",
+        help="Sensor ingest endpoint (default: http://localhost:8000/ingest/sensor)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=2.0,
+        help="Interval in seconds between readings (default: 2.0)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=30.0,
+        help="Total duration in seconds to run the simulation (default: 30)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for deterministic output (default: 42)",
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "endpoint",
-        help="Sensor ingest endpoint, e.g., http://localhost:8000/ingest/sensor",
-    )
-    parser.add_argument(
-        "csv",
-        help="CSV file with ambient_lux,presence[,timestamp]",
-    )
-    args = parser.parse_args()
-    simulate(args.endpoint, args.csv)
+    args = parse_args()
+    simulate(args.endpoint, args.interval, args.duration, args.seed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ TEST_FERNET_KEY = "3hWrYIogeMKAoBFoQVoM23bzb1bqGTGSQhZWWSWxMgI="
 temp_dir = Path(tempfile.mkdtemp())
 os.environ.setdefault("FERNET_KEY", TEST_FERNET_KEY)
 os.environ.setdefault("DB_URL", f"sqlite:///{temp_dir / 'test.db'}")
+os.environ.setdefault("USE_MOCK_DALI", "true")
 BASE_DIR = Path(__file__).resolve().parents[1]
 
 from smart_lighting_ai_dali import config  # noqa: E402

--- a/tests/test_simulation_mode.py
+++ b/tests/test_simulation_mode.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from smart_lighting_ai_dali.dali import MockDALIController
+from smart_lighting_ai_dali.feature_engineering import aggregate_features
+from smart_lighting_ai_dali.models import Decision, RawSensorEvent, WeatherEvent
+from smart_lighting_ai_dali.retention import prune_old_data
+
+
+def _seed_features(db_session) -> None:  # noqa: ANN001
+    now = datetime.utcnow()
+    db_session.add_all(
+        [
+            RawSensorEvent(ambient_lux=220, presence=True, timestamp=now - timedelta(minutes=3)),
+            RawSensorEvent(ambient_lux=180, presence=True, timestamp=now - timedelta(minutes=2)),
+            RawSensorEvent(ambient_lux=260, presence=False, timestamp=now - timedelta(minutes=1)),
+        ]
+    )
+    db_session.add(
+        WeatherEvent(weather_summary="Overcast", temperature_c=15.0, timestamp=now)
+    )
+    db_session.commit()
+    aggregate_features(db_session, window_minutes=5)
+
+
+def test_simulation_predict_control_flow(client, db_session, caplog):  # noqa: ANN001
+    _seed_features(db_session)
+    caplog.set_level(logging.INFO, logger="smart_lighting_ai_dali.dali.interface")
+
+    predict_response = client.post("/predict", json={})
+    assert predict_response.status_code == 200
+
+    control_response = client.post(
+        "/control",
+        json={"intensity": 55, "cct": 4100, "reason": "sim", "source": "test"},
+    )
+    assert control_response.status_code == 200
+    assert control_response.json()["applied"] is True
+
+    controller = client.app.state.control_service.dali
+    assert isinstance(controller, MockDALIController)
+    assert any("Mock DALI applied setpoint" in record.getMessage() for record in caplog.records)
+
+
+def test_simulation_telemetry_pagination(client, db_session):  # noqa: ANN001
+    for idx in range(3):
+        response = client.post(
+            "/control",
+            json={"intensity": 40 + idx * 5, "cct": 3900, "reason": "batch", "source": "test"},
+        )
+        assert response.status_code == 200
+
+    first_page = client.get("/telemetry", params={"limit": 1, "offset": 0})
+    assert first_page.status_code == 200
+    payload = first_page.json()
+    assert payload["next_offset"] == 1
+
+    second_page = client.get("/telemetry", params={"limit": 1, "offset": payload["next_offset"]})
+    assert second_page.status_code == 200
+    assert len(second_page.json()["items"]) == 1
+
+    total_decisions = db_session.query(Decision).count()
+    assert total_decisions >= 3
+
+
+def test_jobs_safe_on_empty_database(db_session):  # noqa: ANN001
+    result = aggregate_features(db_session, window_minutes=5)
+    assert result is None
+
+    counts = prune_old_data(db_session)
+    assert counts["raw"] == 0
+    assert counts["features"] == 0
+    assert counts["decisions"] == 0


### PR DESCRIPTION
## Summary
- add a stateful MockDALIController and settings toggle so FastAPI can run without DALI hardware
- extend scripts and docs with simulation helpers for sensor and weather ingestion
- add regression tests covering simulation flows, telemetry pagination, and retention safety

## Testing
- pytest -k "control or predict" -v
- pytest tests/test_simulation_mode.py -v

------
https://chatgpt.com/codex/tasks/task_e_68e10d53cff48321a8ead8e672708221