### PR TITLE
Improve OpenAI client configuration and admin tooling

### DIFF
--- a/smart_lighting_ai_dali/config.py
+++ b/smart_lighting_ai_dali/config.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     app_name: str = Field("smart-lighting-ai-dali")
     db_url: str = Field("sqlite:///./smart_lighting.db")
     openai_api_key: str | None = Field(default=None)
+    openai_model: str = Field("gpt-4o-mini")
+    openai_enable_reasoning: bool = Field(False)
+    admin_token: str | None = Field(default=None)
     weather_api_key: str | None = Field(default=None)
     fernet_key: str = Field(...)
 

--- a/smart_lighting_ai_dali/tools/__init__.py
+++ b/smart_lighting_ai_dali/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for Smart Lighting AI DALI."""

--- a/smart_lighting_ai_dali/tools/aggregate_once.py
+++ b/smart_lighting_ai_dali/tools/aggregate_once.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+
+from ..config import get_settings
+from ..db import session_scope
+from ..feature_engineering import aggregate_features
+
+
+def main() -> int:
+    """Aggregate a single set of features and report the outcome."""
+    settings = get_settings()
+    try:
+        with session_scope() as session:
+            feature_row = aggregate_features(session, settings.feature_window_minutes)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Aggregation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if feature_row is None:
+        print("No new feature row created.")
+        return 0
+
+    print(
+        "Created feature row",
+        f"id={feature_row.id}",
+        f"window_start={feature_row.window_start.isoformat()}",
+        f"window_end={feature_row.window_end.isoformat()}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ temp_dir = Path(tempfile.mkdtemp())
 os.environ.setdefault("FERNET_KEY", TEST_FERNET_KEY)
 os.environ.setdefault("DB_URL", f"sqlite:///{temp_dir / 'test.db'}")
 os.environ.setdefault("USE_MOCK_DALI", "true")
+os.environ.setdefault("ADMIN_TOKEN", "test-token")
 BASE_DIR = Path(__file__).resolve().parents[1]
 
 from smart_lighting_ai_dali import config  # noqa: E402
@@ -57,11 +58,7 @@ def session() -> Generator:
 def app(session):  # noqa: ANN001
     app = create_app(settings=settings, use_mock_dali=True)
     personal_path = (
-        BASE_DIR
-        / "smart_lighting_ai_dali"
-        / "data"
-        / "examples"
-        / "personal.json"
+        BASE_DIR / "smart_lighting_ai_dali" / "data" / "examples" / "personal.json"
     )
     with open(personal_path, "r", encoding="utf-8") as handle:
         blob = json.load(handle)

--- a/tests/test_admin_endpoints.py
+++ b/tests/test_admin_endpoints.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from smart_lighting_ai_dali.models import RawSensorEvent
+
+
+def test_admin_aggregate_now_requires_auth(client):
+    response = client.post("/admin/aggregate-now")
+    assert response.status_code == 401
+
+
+def test_admin_aggregate_now_creates_features(client, db_session):
+    event = RawSensorEvent(
+        ambient_lux=250,
+        presence=True,
+        timestamp=datetime.utcnow(),
+    )
+    db_session.add(event)
+    db_session.commit()
+
+    response = client.post(
+        "/admin/aggregate-now",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {"created_features": 1}


### PR DESCRIPTION
## Summary
- add OpenAI configuration options to settings and use them when calling the API
- harden health checks and expose an authorized /admin/aggregate-now endpoint
- add a CLI helper to run feature aggregation once and update tests for the new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e136ba16b48321af40aeb92e45c33e