### PR TITLE
Add documentation suite for smart lighting platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ AI-driven control surface for DALI-2 DT8 tunable-white luminaires using the Trid
 - Encrypted personal profile storage using Fernet keys supplied via `.env`.
 - Export utilities and notebook workflow for offline tuning.
 
+## Documentation
+
+- [Executive overview](docs/00-executive-overview.md)
+- [Developer guide](docs/10-developer-guide.md)
+- [Operations runbook](docs/20-operations-runbook.md)
+
 ## Hardware overview
 
 - **Controller**: Tridonic DALI USB (connects to the service host).
@@ -25,6 +31,15 @@ Wiring summary:
 3. Ensure the host running this service can access the USB device (`/dev/ttyACM*`).
 
 ## Getting started
+
+### Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+USE_MOCK_DALI=true uvicorn smart_lighting_ai_dali.main:app --reload
+```
 
 ### Environment
 
@@ -120,6 +135,13 @@ The mock controller mirrors DT8 anti-flicker behaviour, and telemetry grows as `
 ```bash
 http POST :8000/predict
 http POST :8000/control intensity=55 cct=4000 reason="manual tweak" manual_override:=true override_minutes:=30
+```
+
+### Admin endpoint
+
+```bash
+curl -X POST http://localhost:8000/admin/aggregate-now \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
 ```
 
 The `/predict` endpoint only reads the most recent feature windows (1–3 rows) ensuring payloads stay under 2 KiB. `/control` applies DALI DT8 commands, stores decisions, respects anti-flicker guards, and manages manual overrides that auto-expire after 30 minutes.

--- a/docs/00-executive-overview.md
+++ b/docs/00-executive-overview.md
@@ -1,0 +1,90 @@
+# Executive Overview
+
+## What the System Does
+- AI-assisted smart lighting controller tuned for comfort, accessibility, and energy savings.
+- Connects to DALI luminaires to adjust intensity and color temperature automatically or by request.
+- Works with manual overrides so occupants always stay in control.
+
+## Key Data Inputs & Privacy
+| Input | Description |
+| --- | --- |
+| Sensor windows | Rolling summaries of lux, occupancy, and prior commands.
+| Weather snapshots | Temperature and daylight context fetched on schedule.
+| User context | Chronotype and impairment flags stored in encrypted profiles.
+
+**Privacy stance**
+- Only aggregated windows are shared with the AI service.
+- Payload size is capped and batches are limited before leaving the system.
+- Identifiers are pseudonymized, and raw events stay inside the local database.
+
+## Decision Flow
+1. AI model generates the recommended lighting scene.
+2. Rules engine validates outputs, applies accessibility clamps, and handles missing AI responses.
+3. Anti-flicker logic smooths rapid changes before writing DALI commands.
+4. Manual overrides take priority until they expire or are cleared by the user.
+
+## Safety & Guardrails
+- Payload cap, batch limit, and value clamping protect downstream services.
+- Predict and control requests both enforce anti-flicker thresholds.
+- All decisions are logged for audit with minimal personal data.
+
+## Success Measures
+| KPI | Description |
+| --- | --- |
+| Comfort proxy | Self-reported comfort rating or absence of override churn.
+| Energy-saving estimate | Calculated against daylight baseline and historical usage.
+| Uptime | Percentage of successful scheduler ticks and API responses.
+
+## System Flow
+```mermaid
+flowchart LR
+    A[Sensors] --> B[Feature Windows]
+    B --> C{AI / Rules}
+    C --> D[DALI Interface]
+    D --> E[Luminaires]
+```
+
+## Request Flow
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Engine
+    participant DALI
+
+    Client->>API: POST /predict
+    API->>Engine: Build features + call AI
+    Engine-->>API: Lighting recommendation
+    API-->>Client: JSON response
+
+    Client->>API: POST /control
+    API->>Engine: Validate + clamp
+    Engine->>DALI: Send DT8 command
+    DALI-->>API: Ack / status
+    API-->>Client: Decision record
+```
+
+## Admin Flow
+```mermaid
+sequenceDiagram
+    participant Admin
+    participant API
+    participant Scheduler
+    participant DB
+
+    Admin->>API: POST /admin/aggregate-now
+    API->>Scheduler: Trigger aggregation job
+    Scheduler->>DB: Build new feature windows
+    DB-->>Scheduler: Aggregation complete
+    Scheduler-->>API: Success message
+    API-->>Admin: 200 OK + counts
+```
+
+## Glossary
+| Term | Meaning |
+| --- | --- |
+| chronotype | Preferred sleep/wake pattern that influences light needs.
+| impairment_enum | Enum describing accessibility requirements (e.g., low vision).
+| setpoint | Target intensity or color temperature the system aims to achieve.
+| CCT | Correlated color temperature, measured in Kelvin.
+| payload cap | Maximum bytes allowed in an outgoing AI payload.

--- a/docs/10-developer-guide.md
+++ b/docs/10-developer-guide.md
@@ -1,0 +1,131 @@
+# Developer Guide
+
+## Architecture Overview
+| Module | Responsibility |
+| --- | --- |
+| `smart_lighting_ai_dali/main.py` | FastAPI app factory, lifespan scheduler wiring, route registration. |
+| `smart_lighting_ai_dali/control_service.py` | Core orchestration for `/predict` and `/control`, manual override handling, guardrails. |
+| `smart_lighting_ai_dali/openai_client.py` | Builds AI payloads, enforces payload cap, handles retries, parses function-call JSON. |
+| `smart_lighting_ai_dali/feature_engineering.py` | Window builders, aggregation jobs, feature schemas. |
+| `smart_lighting_ai_dali/models.py` | SQLAlchemy ORM models, enums, helpers. |
+| `smart_lighting_ai_dali/retention.py` | Scheduled pruning routines for raw and feature tables. |
+| `smart_lighting_ai_dali/dali/` | DALI DT8 driver, mock implementations, hardware adapters. |
+
+## Local Development Setup
+1. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[dev]
+   ```
+2. Copy `.env.example` to `.env` and set the following keys:
+
+| Key | Purpose | Example |
+| --- | --- | --- |
+| `DB_URL` | SQLAlchemy URL (defaults to SQLite file). | `sqlite:///./smart_lighting.db`
+| `USE_MOCK_DALI` | Toggle mock driver for local dev. | `true`
+| `ENABLE_OPENAI` | Explicit toggle for AI calls. | `false`
+| `OPENAI_API_KEY` | Secret for OpenAI client when enabled. | `sk-...`
+| `OPENAI_MODEL` | Model name string used by client. | `gpt-4o-mini`
+| `FERNET_KEY` | Encryption key for personal profiles. | `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+| `PAYLOAD_CAP_BYTES` | Max outbound payload size. | `2048`
+| `ADMIN_TOKEN` | Bearer token required by admin routes. | `local-admin-token`
+
+> Missing `FERNET_KEY` prevents the app from booting because encrypted profile access fails.
+
+## Running Locally
+- Launch API with mock DALI:
+  ```bash
+  USE_MOCK_DALI=true uvicorn smart_lighting_ai_dali.main:app --reload
+  ```
+- Seed example events:
+  ```bash
+  python scripts/simulate_sensor.py --interval 2 --duration 60
+  python scripts/ingest_weather.py --interval 60 --duration 3
+  ```
+- Aggregate features manually:
+  ```bash
+  python - <<'PY'
+  from smart_lighting_ai_dali.db import session_scope
+  from smart_lighting_ai_dali.feature_engineering import aggregate_features
+
+  with session_scope() as session:
+      aggregate_features(session, window_minutes=5)
+  PY
+  ```
+- Call endpoints with `httpie` or curl/PowerShell (examples below).
+
+## AI Payload Construction
+1. `control_service.build_ai_payload()` (via `openai_client`) collects latest feature windows capped by `PAYLOAD_BATCH_LIMIT`.
+2. Payload dictionary is serialized to JSON and truncated if it exceeds `PAYLOAD_CAP_BYTES`.
+3. Client sends a function call request; JSON schema expects fields like `intensity`, `cct`, `reason`, `expires_at`.
+4. Responses are validated; missing or malformed fields trigger the rules fallback defined in `control_service.rules_fallback()`.
+5. Final outputs are clamped to safe intensity/CCT ranges before dispatch to DALI.
+
+## Testing
+- Targeted tests:
+  ```bash
+  pytest -k "control or predict"
+  ```
+- Full suite:
+  ```bash
+  pytest
+  ```
+
+## Extending the Models
+- Add new columns or tables in `models.py`, then generate migrations if using an external DB.
+- Update feature builders to surface the new data and adjust payload serialization.
+- When adding a new `impairment_enum` rule:
+  1. Extend the enum definition in `models.py`.
+  2. Update rule handling in `control_service.apply_accessibility_rules()`.
+  3. Add tests covering the new branch (`tests/test_control_service.py`).
+
+## Endpoint Examples
+### `/predict`
+```bash
+curl -X POST http://localhost:8000/predict \
+     -H "Content-Type: application/json" \
+     -d '{}'
+```
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/predict" -Body '{}' -ContentType 'application/json'
+```
+
+### `/control`
+```bash
+curl -X POST http://localhost:8000/control \
+     -H "Content-Type: application/json" \
+     -d '{"manual_override": true, "intensity": 55, "cct": 4000, "override_minutes": 30}'
+```
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/control" \
+  -Body '{"manual_override": true, "intensity": 55, "cct": 4000, "override_minutes": 30}' \
+  -ContentType 'application/json'
+```
+
+### `/admin/aggregate-now`
+```bash
+curl -X POST http://localhost:8000/admin/aggregate-now \
+     -H "Authorization: Bearer ${ADMIN_TOKEN}"
+```
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/admin/aggregate-now" \
+  -Headers @{ Authorization = "Bearer $env:ADMIN_TOKEN" }
+```
+
+### `/healthz`
+```bash
+curl http://localhost:8000/healthz
+```
+```powershell
+Invoke-RestMethod -Uri "http://localhost:8000/healthz"
+```
+
+## Troubleshooting
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| `.env` fails to load | Formatting or quoting issue in dotenv. | Check for stray quotes; use `KEY=value` lines only. |
+| `FERNET_KEY` missing error | Key unset or malformed. | Regenerate with `Fernet.generate_key()` and export it. |
+| SQLite locked | Concurrent writer while running retention job. | Wait a few seconds or run with WAL mode: `PRAGMA journal_mode=WAL;`. |
+| OpenAI retries warning | Transient 429/5xx response. | Retries are automatic; confirm `ENABLE_OPENAI` and network access. |
+| No features aggregated | Scheduler not running or DB empty. | Trigger `/admin/aggregate-now` and ensure ingestion scripts are active. |

--- a/docs/20-operations-runbook.md
+++ b/docs/20-operations-runbook.md
@@ -1,0 +1,53 @@
+# Operations Runbook
+
+## Lifecycle
+- `main.py` uses FastAPI lifespan to start the scheduler, register aggregation and retention jobs, and open the DALI interface.
+- Shutdown waits for running jobs, flushes telemetry, and releases USB handles before closing the DB session factory.
+
+## Health Checks
+- `GET /healthz` returns:
+  - `status: ok` when API, scheduler heartbeat, and DB connectivity succeed within the timeout.
+  - `status: degraded` when non-critical dependencies (OpenAI, weather) are failing.
+  - `status: error` when DB or DALI drivers are unavailable; check logs immediately.
+
+## Credential Rotation
+1. Update `.env` or secret manager values (`ADMIN_TOKEN`, `OPENAI_API_KEY`, `FERNET_KEY`).
+2. Restart the service so the lifespan hook reloads settings and refreshes scheduler contexts.
+3. For `FERNET_KEY` changes, re-encrypt stored profiles before restart to maintain readability.
+
+## Database Care
+- Default SQLite file lives at `./smart_lighting_ai_dali.db` unless `DB_URL` overrides it.
+- Retention job (`retention.py`) prunes raw events (30d), features (90d), and decisions (180d) on schedule.
+- Run `/admin/aggregate-now` to refill features if ingestion outpaces pruning.
+
+## Observability
+- Structured logs emitted via `smart_lighting_ai_dali` logger hierarchy.
+- Key logger names: `control_service`, `openai_client`, `feature_engineering`, `retention`, `dali.driver`.
+- Typical warnings:
+  - `openai_client` retry notices on 429/500 responses.
+  - `db.health` warnings when the health checker catches slow queries.
+  - `dali.driver` toggling to mock mode when hardware disconnects.
+
+## Incident Playbooks
+| Incident | Immediate Actions |
+| --- | --- |
+| No features available | Check ingestion scripts; run `/admin/aggregate-now`; verify scheduler heartbeat in logs. |
+| Payload exceeds cap | Inspect payload dump in `openai_client`; reduce `PAYLOAD_BATCH_LIMIT` or adjust feature window size. |
+| DB health = error | Confirm disk space; restart service; consider enabling WAL; restore from backup if corrupt. |
+| DALI offline | If mock mode: restart simulator; if hardware: reseat USB, confirm `/dev/ttyACM*`, fall back to rules-only mode. |
+
+## Backup & Restore
+- Stop the service to avoid partial writes.
+- Copy the SQLite file and the `./backups/` directory if present.
+- To restore, replace the file with the backup copy and restart; feature aggregation will rebuild derived tables.
+- For zero-downtime upgrades, run the new container pointing at the same volume after taking a snapshot.
+
+## Upgrades
+- Apply migrations if schema changed (Alembic or manual script).
+- Use rolling deployment: bring up new pod with updated image, run health check, switch traffic, retire old pod.
+- Ensure retention job version matches schema before resuming full traffic.
+
+## Security Notes
+- Keep `ADMIN_TOKEN` scoped and rotate quarterly; only ops endpoints require it.
+- Apply principle of least privilege for host USB access and database credentials.
+- Monitor audit logs for repeated admin requests or failed authentications.


### PR DESCRIPTION
## Summary
- add executive overview, developer guide, and operations runbook under docs/
- link new documentation from README and provide quick start instructions
- document admin aggregate endpoint usage in README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13a2f711483218ca67037ddb19d25