### PR TITLE
Add secure admin aggregation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Wiring summary:
    - `OPENAI_API_KEY` – optional; when unset, the rules-based fallback is used.
    - `WEATHER_API_KEY` – optional upstream integration key.
    - `DB_URL` – database connection string (default SQLite file).
+   - `ADMIN_TOKEN` – Bearer token required for secure admin calls (example: `super-secret-admin-token`).
 3. Install dependencies:
    ```bash
    pip install -e .[dev]
@@ -123,6 +124,16 @@ http POST :8000/control intensity=55 cct=4000 reason="manual tweak" manual_overr
 ```
 
 The `/predict` endpoint only reads the most recent feature windows (1–3 rows) ensuring payloads stay under 2 KiB. `/control` applies DALI DT8 commands, stores decisions, respects anti-flicker guards, and manages manual overrides that auto-expire after 30 minutes.
+
+### Admin endpoint
+
+Trigger feature aggregation on demand with a Bearer token:
+
+```bash
+http POST :8000/admin/aggregate-now "Authorization:Bearer super-secret-admin-token"
+```
+
+The endpoint responds with `{ "ok": true }` when the aggregation runs successfully.
 
 ## Data policy and retention
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from smart_lighting_ai_dali import config
+from smart_lighting_ai_dali.main import create_app
+
+
+def test_aggregate_now_success(client):
+    response = client.post(
+        "/admin/aggregate-now",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_aggregate_now_missing_token(client):
+    response = client.post("/admin/aggregate-now")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Missing or invalid token"}
+
+
+def test_aggregate_now_wrong_token(client):
+    response = client.post(
+        "/admin/aggregate-now",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+
+
+def test_aggregate_now_requires_config(monkeypatch):
+    monkeypatch.delenv("ADMIN_TOKEN", raising=False)
+    config.get_settings.cache_clear()  # type: ignore[attr-defined]
+    settings = config.get_settings()
+    app = create_app(settings=settings, use_mock_dali=True)
+    with TestClient(app) as temp_client:
+        response = temp_client.post(
+            "/admin/aggregate-now",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Admin token not configured"}
+    config.get_settings.cache_clear()  # type: ignore[attr-defined]

--- a/tests/test_admin_endpoints.py
+++ b/tests/test_admin_endpoints.py
@@ -25,4 +25,4 @@ def test_admin_aggregate_now_creates_features(client, db_session):
     )
     assert response.status_code == 200
     payload = response.json()
-    assert payload == {"created_features": 1}
+    assert payload == {"ok": True}


### PR DESCRIPTION
## Summary
- add an admin-token-protected helper and dependency for the on-demand aggregation endpoint
- return a lightweight {"ok": true} payload and document the ADMIN_TOKEN usage in the README
- add regression tests covering success, missing token, wrong token, and missing configuration scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e13a2254248321a0725f80141d7d41