### PR TITLE
Support basic Tridonic DALI USB broadcast mode

### DIFF
--- a/smart_lighting_ai_dali/config.py
+++ b/smart_lighting_ai_dali/config.py
@@ -41,6 +41,12 @@ class Settings(BaseSettings):
     min_update_interval_seconds: int = Field(5)
 
     use_mock_dali: bool = Field(False, validation_alias="USE_MOCK_DALI")
+    # Flag enabling legacy Tridonic adapters that only understand broadcast dimming.
+    dali_basic_mode: bool = Field(
+        False,
+        validation_alias=AliasChoices("DALI_BASIC_MODE", "dali_basic_mode"),
+        description="Flag to force broadcast-only Tridonic USB mode.",
+    )
 
     quiet_hours_start: int = Field(22)
     quiet_hours_end: int = Field(6)

--- a/smart_lighting_ai_dali/main.py
+++ b/smart_lighting_ai_dali/main.py
@@ -66,7 +66,7 @@ def create_app(
     dali = (
         MockDALIController(settings=settings)
         if use_mock_dali
-        else TridonicUSBInterface()
+        else TridonicUSBInterface(settings=settings)
     )
     control_service = ControlService(dali=dali, settings=settings)
     ai_controller = AIController(settings=settings, client=None)


### PR DESCRIPTION
## Summary
- add a configuration flag to force basic Tridonic USB broadcast behaviour and surface it through the hardware interface
- adjust the Tridonic USB adapter stub to emit broadcast-only intensity commands and expose DT8 capability for the control service
- ensure control logic skips CCT adjustments when DT8 is unavailable while keeping existing DT8 behaviour unchanged

## Testing
- pytest *(fails: missing cryptography dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc02d84348321b966f2c050d6778a